### PR TITLE
Update run.yml

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,8 +14,12 @@ jobs:
     steps:
       - name: Convert deb to IPA
         run: |
+          # Extract the filename from the deb URL
+          deb_url="${{ github.event.inputs.deb }}"
+          deb_filename=$(basename "$deb_url" .deb)
+
           # Download the .deb file
-          curl -L -o ${{ github.workspace }}/app.deb "${{ github.event.inputs.deb }}"
+          curl -L -o ${{ github.workspace }}/app.deb "$deb_url"
           
           # Extract the contents of the .deb file
           dpkg-deb -X ${{ github.workspace }}/app.deb ${{ github.workspace }}/app
@@ -34,13 +38,13 @@ jobs:
             exit 1
           fi
           
-          # Create the IPA file
+          # Create the IPA file using the .deb filename
           cd ${{ github.workspace }}/ipa
-          zip -r App.ipa Payload
+          zip -r "${deb_filename}.ipa" Payload
 
           # Ensure the IPA file exists
-          if [ -f "App.ipa" ]; then
-            echo "IPA created successfully!"
+          if [ -f "${deb_filename}.ipa" ]; then
+            echo "IPA created successfully as ${deb_filename}.ipa!"
           else
             echo "IPA creation failed."
             exit 1
@@ -50,4 +54,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: App
-          path: ${{ github.workspace }}/ipa/App.ipa
+          path: ${{ github.workspace }}/ipa/*.ipa

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,12 +14,27 @@ jobs:
     steps:
       - name: Convert deb to IPA
         run: |
+          # Download the .deb file
           curl -L -o ${{ github.workspace }}/app.deb "${{ github.event.inputs.deb }}"
+          
+          # Extract the contents of the .deb file
           dpkg-deb -X ${{ github.workspace }}/app.deb ${{ github.workspace }}/app
 
+          # Create the IPA Payload directory
           mkdir -p ${{ github.workspace }}/ipa/Payload
-          cp -R ${{ github.workspace }}/app/Applications/* ${{ github.workspace }}/ipa/Payload
+
+          # Copy files from possible app locations
+          if [ -d "${{ github.workspace }}/app/Applications" ]; then
+            cp -R ${{ github.workspace }}/app/Applications/* ${{ github.workspace }}/ipa/Payload
+          elif [ -d "${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries" ]; then
+            # Assuming the app might be here; adjust as necessary based on the structure
+            cp -R ${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries/* ${{ github.workspace }}/ipa/Payload
+          else
+            echo "No application files found in expected directories."
+            exit 1
+          fi
           
+          # Create the IPA file
           cd ${{ github.workspace }}/ipa
           zip -r ${{ github.workspace }}/App.ipa .
 
@@ -27,4 +42,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: App
-          path: ${{ github.workspace }}/App.ipa
+          path: ${{ github.workspace }}/ipa/App.ipa

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,20 +23,28 @@ jobs:
           # Create the IPA Payload directory
           mkdir -p ${{ github.workspace }}/ipa/Payload
 
-          # Copy files from possible app locations
+          # Copy extracted files to Payload
           if [ -d "${{ github.workspace }}/app/Applications" ]; then
             cp -R ${{ github.workspace }}/app/Applications/* ${{ github.workspace }}/ipa/Payload
           elif [ -d "${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries" ]; then
-            # Assuming the app might be here; adjust as necessary based on the structure
-            cp -R ${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries/* ${{ github.workspace }}/ipa/Payload
+            mkdir -p ${{ github.workspace }}/ipa/Payload/Library/MobileSubstrate/DynamicLibraries
+            cp -R ${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries/* ${{ github.workspace }}/ipa/Payload/Library/MobileSubstrate/DynamicLibraries
           else
-            echo "No application files found in expected directories."
+            echo "No valid application files found in expected directories."
             exit 1
           fi
           
           # Create the IPA file
           cd ${{ github.workspace }}/ipa
-          zip -r ${{ github.workspace }}/App.ipa .
+          zip -r App.ipa Payload
+
+          # Ensure the IPA file exists
+          if [ -f "App.ipa" ]; then
+            echo "IPA created successfully!"
+          else
+            echo "IPA creation failed."
+            exit 1
+          fi
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,12 +27,12 @@ jobs:
           # Create the IPA Payload directory
           mkdir -p ${{ github.workspace }}/ipa/Payload
 
-          # Copy extracted files to Payload
-          if [ -d "${{ github.workspace }}/app/Applications" ]; then
-            cp -R ${{ github.workspace }}/app/Applications/* ${{ github.workspace }}/ipa/Payload
-          elif [ -d "${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries" ]; then
+          # Check if the extracted files are in var/jb/Applications or Library
+          if [ -d "${{ github.workspace }}/app/var/jb/Applications" ]; then
+            cp -R ${{ github.workspace }}/app/var/jb/Applications/* ${{ github.workspace }}/ipa/Payload
+          elif [ -d "${{ github.workspace }}/app/var/jb/Library/MobileSubstrate/DynamicLibraries" ]; then
             mkdir -p ${{ github.workspace }}/ipa/Payload/Library/MobileSubstrate/DynamicLibraries
-            cp -R ${{ github.workspace }}/app/Library/MobileSubstrate/DynamicLibraries/* ${{ github.workspace }}/ipa/Payload/Library/MobileSubstrate/DynamicLibraries
+            cp -R ${{ github.workspace }}/app/var/jb/Library/MobileSubstrate/DynamicLibraries/* ${{ github.workspace }}/ipa/Payload/Library/MobileSubstrate/DynamicLibraries
           else
             echo "No valid application files found in expected directories."
             exit 1


### PR DESCRIPTION
Checking for the Correct Path: The script now checks if the Applications directory exists. If it doesn’t, it looks in Library/MobileSubstrate/DynamicLibraries or other relevant paths depending on where the files are located in the .deb. Fail Gracefully: If no appropriate directory is found, the script exits with a message indicating that no application files were found. This adjustment should prevent the script from failing due to missing directories.